### PR TITLE
[#6] Block vote when options are not set

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,17 +139,17 @@ with gr.Blocks(title="Arena") as app:
       model_names[0] = gr.Textbox(label="Model A", interactive=False)
       model_names[1] = gr.Textbox(label="Model B", interactive=False)
 
+  vote_buttons = [option_a, option_b, tie]
   instruction_state = gr.State("")
 
-  submit.click(get_responses,
-               [prompt, category_radio, source_language, target_language],
-               response_boxes + model_names + [instruction_state])
+  submit.click(
+      get_responses, [prompt, category_radio, source_language, target_language],
+      response_boxes + model_names + vote_buttons + [instruction_state])
 
   common_inputs = response_boxes + model_names + [
       prompt, instruction_state, category_radio, source_language,
       target_language
   ]
-  vote_buttons = [option_a, option_b, tie]
   option_a.click(vote, [option_a] + common_inputs, vote_buttons)
   option_b.click(vote, [option_b] + common_inputs, vote_buttons)
   tie.click(vote, [tie] + common_inputs, vote_buttons)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ google-api-python-client==2.116.0
 google-auth==2.27.0
 google-auth-httplib2==0.2.0
 google-cloud-aiplatform==1.40.0
-google-cloud-bigquery==3.17.1
+google-cloud-bigquery==3.17.2
 google-cloud-core==2.4.1
 google-cloud-firestore==2.14.0
 google-cloud-resource-manager==1.12.0

--- a/response.py
+++ b/response.py
@@ -86,7 +86,9 @@ def get_responses(user_prompt, category, source_lang, target_lang):
         responses[i] += yielded
         stop = False
 
-        yield responses + models + [instruction]
+        yield responses + models + [
+            gr.Button(interactive=True) for _ in range(3)
+        ] + [instruction]
 
       except StopIteration:
         pass


### PR DESCRIPTION
Changes:
- Blocked voting when the response type is not set.
- Blocked voting when the response type is 'Translate' and the source/target languages are not set.
- Blocked voting when a user already voted.

Fixes #6 