### PR TITLE
[#7] Display model names only after voting

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,7 +144,8 @@ with gr.Blocks(title="Arena") as app:
 
   submit.click(
       get_responses, [prompt, category_radio, source_language, target_language],
-      response_boxes + model_names + vote_buttons + [instruction_state])
+      response_boxes + model_names + vote_buttons +
+      [instruction_state, model_name_row])
 
   common_inputs = response_boxes + model_names + [
       prompt, instruction_state, category_radio, source_language,

--- a/response.py
+++ b/response.py
@@ -88,7 +88,7 @@ def get_responses(user_prompt, category, source_lang, target_lang):
 
         yield responses + models + [
             gr.Button(interactive=True) for _ in range(3)
-        ] + [instruction]
+        ] + [instruction, gr.Row(visible=False)]
 
       except StopIteration:
         pass


### PR DESCRIPTION
Changes:
- Displayed model names only after a user has voted for a model.
- Moved the model name section to the bottom of the model responses.

Screenshot: https://screen.yanolja.in/tlwjKwGkIMAeIXuo.png
![image](https://github.com/Y-IAB/arena/assets/124246127/55c060c4-66a3-4a5d-8b34-b1e50def8f42)

Fixes #7
