### PR TITLE
[#30] Fetch the model list from the Secret Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@
    Set your OpenAI API key as an environment variable and start the application:
 
    ```shell
-   GOOGLE_CLOUD_PROJECT=<your project id> CREDENTIALS_PATH=<your crednetials path> OPENAI_API_KEY=<your key> python3 app.py
+   GOOGLE_CLOUD_PROJECT=<your project id> \
+   CREDENTIALS_PATH=<your crednetials path> \
+   MODELS_SECRET=<your secret> \
+   OPENAI_API_KEY=<your key> \
+   python3 app.py
    ```
 
-   Replace `<your project id>`, `<your crednetials path>`, and `<your key>` with your GCP project ID, the path to your GCP credentials file, and your OpenAI API key respectively.
+   Replace `<your project id>`, `<your crednetials path>`, `<your secret>`, and `<your key>` with your GCP project ID, the path to your GCP credentials file, the secret name for your models, and your OpenAI API key respectively.
 
    > To run the app with [auto-reloading](https://www.gradio.app/guides/developing-faster-with-reload-mode), use `gradio app.py --demo-name app` instead of `python3 app.py`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,11 +27,12 @@ google-api-core==2.16.2
 google-api-python-client==2.116.0
 google-auth==2.27.0
 google-auth-httplib2==0.2.0
-google-cloud-aiplatform==1.40.0
-google-cloud-bigquery==3.17.2
+google-cloud-aiplatform==1.43.0
+google-cloud-bigquery==3.19.0
 google-cloud-core==2.4.1
 google-cloud-firestore==2.14.0
-google-cloud-resource-manager==1.12.0
+google-cloud-resource-manager==1.12.3
+google-cloud-secret-manager==2.18.3
 google-cloud-storage==2.14.0
 google-crc32c==1.5.0
 google-resumable-media==2.7.0
@@ -90,7 +91,7 @@ rpds-py==0.17.1
 rsa==4.9
 ruff==0.2.0
 semantic-version==2.10.0
-shapely==2.0.2
+shapely==2.0.3
 shellingham==1.5.4
 six==1.16.0
 sniffio==1.3.0

--- a/response.py
+++ b/response.py
@@ -3,15 +3,24 @@ This module contains functions for generating responses using LLMs.
 """
 
 import enum
+import json
+import os
 from random import sample
 
+from google.cloud import secretmanager
 import gradio as gr
 from litellm import completion
 
-# TODO(#1): Add more models.
-SUPPORTED_MODELS = [
-    "gpt-4", "gpt-4-0125-preview", "gpt-3.5-turbo", "gemini-pro"
-]
+GOOGLE_CLOUD_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT")
+MODELS_SECRET = os.environ.get("MODELS_SECRET")
+
+secretmanagerClient = secretmanager.SecretManagerServiceClient()
+models_secret = secretmanagerClient.access_secret_version(
+    name=secretmanagerClient.secret_version_path(GOOGLE_CLOUD_PROJECT,
+                                                 MODELS_SECRET, "latest"))
+decoded_secret = models_secret.payload.data.decode("UTF-8")
+
+supported_models = json.loads(decoded_secret)
 
 
 class Category(enum.Enum):
@@ -47,16 +56,25 @@ def get_responses(user_prompt, category, source_lang, target_lang):
                                                not target_lang):
     raise gr.Error("Please select source and target languages.")
 
-  models = sample(SUPPORTED_MODELS, 2)
+  models = sample(list(supported_models), 2)
   instruction = get_instruction(category, source_lang, target_lang)
   activated_vote_buttons = [gr.Button(interactive=True) for _ in range(3)]
   deactivated_vote_buttons = [gr.Button(interactive=False) for _ in range(3)]
 
   generators = []
   for model in models:
+    model_config = supported_models[model]
+
+    model_name = model_config[
+        "provider"] + "/" + model if "provider" in model_config else model
+    api_key = model_config.get("apiKey", None)
+    api_base = model_config.get("apiBase", None)
+
     try:
       # TODO(#1): Allow user to set configuration.
-      response = completion(model=model,
+      response = completion(model=model_name,
+                            api_key=api_key,
+                            api_base=api_base,
                             messages=[{
                                 "content": instruction,
                                 "role": "system"


### PR DESCRIPTION
The model list is now fetched from the Secret Manager. It will allow us to add open-source models without changing the code.

Current list of models:
```json
{
  "gpt-4": {},
  "gpt-4-0125-preview": {},
  "gpt-3.5-turbo": {},
  "gemini-pro": {},
  "yanolja/EEVE-Korean-Instruct-10.8B-v1.0": {
    "provider": "openai",
    "apiKey": "...",
    "apiBase": "..."
  }
}

```

Resolves #30