### PR TITLE
[#20] Add scroll functionality to response textboxes

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,6 +88,15 @@ def vote(vote_button, response_a, response_b, model_a_name, model_b_name,
   raise gr.Error("Please select a response type.")
 
 
+def scroll_to_bottom_js(elem_id):
+  return f"""
+  () => {{
+    const element = document.querySelector("#{elem_id} textarea");
+    element.scrollTop = element.scrollHeight;
+  }}
+  """
+
+
 with gr.Blocks(title="Arena") as app:
   with gr.Row():
     category_radio = gr.Radio(
@@ -126,8 +135,21 @@ with gr.Blocks(title="Arena") as app:
 
   with gr.Group():
     with gr.Row():
-      response_boxes[0] = gr.Textbox(label="Model A", interactive=False)
-      response_boxes[1] = gr.Textbox(label="Model B", interactive=False)
+      response_a_elem_id = "responseA"
+      response_a_textbox = gr.Textbox(label="Model A",
+                                      interactive=False,
+                                      elem_id=response_a_elem_id)
+      response_a_textbox.change(fn=None,
+                                js=scroll_to_bottom_js(response_a_elem_id))
+      response_boxes[0] = response_a_textbox
+
+      response_b_elem_id = "responseB"
+      response_b_textbox = gr.Textbox(label="Model B",
+                                      interactive=False,
+                                      elem_id=response_b_elem_id)
+      response_b_textbox.change(fn=None,
+                                js=scroll_to_bottom_js(response_b_elem_id))
+      response_boxes[1] = response_b_textbox
 
     with gr.Row(visible=False) as model_name_row:
       model_names[0] = gr.Textbox(show_label=False)


### PR DESCRIPTION
# Problem
When a response length exceeds a certain length, the text box does not scroll to the bottom to show the remaining text.

https://github.com/Y-IAB/arena/assets/124246127/f2d704d5-cd26-47e5-a1ff-ff112a73e812

The text box does not scroll to the bottom. We need to do it ourselves.


There are two ways to fix this:
1. Display the scroll bar and let the user scroll to the bottom. When it reaches the bottom, the scroll bar will automatically scroll to the bottom.
2. Automatically scroll to the bottom when the response text is generated.

# Changes
This PR implements the second option since it's cumbersome to scroll to the bottom manually.

When the response text is generated, `element.scrollTop = element.scrollHeight` is triggered to scroll to the bottom of the text box. It's not the most efficient way to do this, but it's the simplest way to do it.

https://github.com/Y-IAB/arena/assets/124246127/8c994698-8c7a-4249-9f90-7dd70fab18aa


Resolves #20 