### PR TITLE
[#29] Display responses simultaneously to prevent bias from generation speed

### DIFF
--- a/response.py
+++ b/response.py
@@ -59,7 +59,7 @@ def get_responses(user_prompt, category, source_lang, target_lang):
       print(f"Error in bot_response: {e}")
       raise e
 
-  # It simulates concurrent stream response generation from two models.
+  # It simulates concurrent stream response generation.
   max_response_length = max(len(response) for response in responses)
   for i in range(max_response_length):
     yield [response[:i + 1] for response in responses


### PR DESCRIPTION
Changes:
- Fetch responses with disabled streaming
- It takes longer to display responses because the entire response is fetched
- Simulate streaming by slicing responses into chunks since it's the common UX pattern


https://github.com/Y-IAB/arena/assets/124246127/3c5c47b1-2364-4215-92c1-f61fc9e66bc0


Resolves #29