### PR TITLE
[#42] Hide vote buttons when generation fails

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,13 +141,12 @@ with gr.Blocks(title="Arena") as app:
   submit.click(
       fn=get_responses,
       inputs=[prompt, category_radio, source_language, target_language],
-      outputs=response_boxes + model_names + [instruction_state]).then(
-          fn=lambda: [gr.Button(interactive=True),
-                      gr.Row(visible=True)
+      outputs=response_boxes + model_names + [instruction_state]).success(
+          fn=lambda: [gr.Row(visible=True)
                      ] + [gr.Button(interactive=True) for _ in range(3)],
-          outputs=[submit, vote_row] + vote_buttons)
+          outputs=[vote_row] + vote_buttons).then(
+              fn=lambda: [gr.Button(interactive=True)], outputs=[submit])
 
-  # TODO(#42): Hide vote buttons until response generation is successful.
   submit.click(fn=lambda: [
       gr.Button(interactive=False),
       gr.Row(visible=False),

--- a/response.py
+++ b/response.py
@@ -77,8 +77,8 @@ def get_responses(user_prompt, category, source_lang, target_lang):
 
     # TODO(#1): Narrow down the exception type.
     except Exception as e:  # pylint: disable=broad-except
-      print(f"Error in bot_response: {e}")
-      raise e
+      print(f"Error with model {model}: {e}")
+      raise gr.Error("Failed to get response. Please try again.")
 
   # It simulates concurrent stream response generation.
   max_response_length = max(len(response) for response in responses)


### PR DESCRIPTION
Changes:
- Hide vote buttons when generation fails
- Update the generation failure message

Screenshot: https://screen.yanolja.in/mylSFgXusvrhUaxu.png
![image](https://github.com/Y-IAB/arena/assets/124246127/a9a12e76-f7bd-4902-8816-8724e1efdb97)

Resolves #42
