### PR TITLE
[#52] Fix building leaderboard error with no battles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 venv
 *.log
 __pycache__
-credentials.json
+credentials*.json

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -64,6 +64,9 @@ def load_elo_ratings(tab):
         "winner": data["winner"]
     })
 
+  if not battles:
+    return
+
   battles = pd.DataFrame(battles)
   ratings = compute_elo(battles)
 


### PR DESCRIPTION
This change fixes an error that occurs when the leaderboard is built with no battles.

Screenshot: https://screen.yanolja.in/V6Aw8l882wZ2cuCd.png
![image](https://github.com/Y-IAB/arena/assets/124246127/0d79d4d5-953f-4382-af2f-ee363e3e7963)


Fixes #52