### PR TITLE
[#54] Save all LLM responses regardless of user voting

### DIFF
--- a/response.py
+++ b/response.py
@@ -6,13 +6,16 @@ import enum
 import json
 import os
 from random import sample
+from uuid import uuid4
 
+from firebase_admin import firestore
 from google.cloud import secretmanager
 from google.oauth2 import service_account
 import gradio as gr
 from litellm import completion
 
 from credentials import get_credentials_json
+from leaderboard import db
 
 GOOGLE_CLOUD_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT")
 MODELS_SECRET = os.environ.get("MODELS_SECRET")
@@ -26,6 +29,23 @@ models_secret = secretmanager_client.access_secret_version(
 decoded_secret = models_secret.payload.data.decode("UTF-8")
 
 supported_models = json.loads(decoded_secret)
+
+
+def create_history(model_name: str, instruction: str, prompt: str,
+                   response: str):
+  doc_id = uuid4().hex
+
+  doc = {
+      "id": doc_id,
+      "model": model_name,
+      "instruction": instruction,
+      "prompt": prompt,
+      "response": response,
+      "timestamp": firestore.SERVER_TIMESTAMP
+  }
+
+  doc_ref = db.collection("arena-history").document(doc_id)
+  doc_ref.set(doc)
 
 
 class Category(enum.Enum):
@@ -73,7 +93,9 @@ def get_responses(user_prompt, category, source_lang, target_lang):
                                 "content": user_prompt,
                                 "role": "user"
                             }])
-      responses.append(response.choices[0].message.content)
+      content = response.choices[0].message.content
+      create_history(model, instruction, user_prompt, content)
+      responses.append(content)
 
     # TODO(#1): Narrow down the exception type.
     except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
This change aims to ensure all LLM responses are saved, independent of user voting.

**Responses are stored in both the `history` and the relevant `summarization` or `translation` tables.** This facilitates easier access to battle data without needing to query the history table.

Resolves #54 