### PR TITLE
[#60] Remove persistent orange border from leaderboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,15 @@ def scroll_to_bottom_js(elem_id):
   """
 
 
-with gr.Blocks(title="Arena") as app:
+# Removes the persistent orange border from the leaderboard, which
+# appears due to the 'generating' class when using the 'every' parameter.
+css = """
+.leaderboard .generating {
+  border: none;
+}
+"""
+
+with gr.Blocks(title="Arena", css=css) as app:
   with gr.Row():
     category_radio = gr.Radio(
         [category.value for category in response.Category],

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -90,7 +90,8 @@ def build_leaderboard():
       gr.Dataframe(headers=["Rank", "Model", "Elo rating"],
                    datatype=["number", "str", "number"],
                    value=load_summarization_elo_ratings,
-                   every=LEADERBOARD_UPDATE_INTERVAL)
+                   every=LEADERBOARD_UPDATE_INTERVAL,
+                   elem_classes="leaderboard")
       gr.Markdown(LEADERBOARD_INFO)
 
     # TODO(#9): Add language filter options.
@@ -98,5 +99,6 @@ def build_leaderboard():
       gr.Dataframe(headers=["Rank", "Model", "Elo rating"],
                    datatype=["number", "str", "number"],
                    value=load_translation_elo_ratings,
-                   every=LEADERBOARD_UPDATE_INTERVAL)
+                   every=LEADERBOARD_UPDATE_INTERVAL,
+                   elem_classes="leaderboard")
       gr.Markdown(LEADERBOARD_INFO)


### PR DESCRIPTION
This change removes the orange border from the leaderboard so that it won't overlap with other elements on the page.


Before Change
![image](https://github.com/Y-IAB/arena/assets/124246127/675e48a0-c6e1-4a35-8f97-a2de39902920)

After Change
![image](https://github.com/Y-IAB/arena/assets/124246127/6eb66653-1dcc-4d57-bd94-5015feeac976)


Fixes #60 