### PR TITLE
[#69] Set GOOGLE_APPLICATION_CREDENTIALS with a temp credentials file

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from firebase_admin import firestore
 import gradio as gr
 
+import credentials
 from credentials import set_credentials
 from leaderboard import build_leaderboard
 from leaderboard import db
@@ -172,7 +173,7 @@ with gr.Blocks(title="Arena", css=css) as app:
   build_leaderboard()
 
 if __name__ == "__main__":
-  set_credentials()
+  set_credentials(credentials.CREDENTIALS, credentials.CREDENTIALS_PATH)
 
   # We need to enable queue to use generators.
   app.queue()

--- a/credentials.py
+++ b/credentials.py
@@ -5,6 +5,7 @@ required for authentication with GCP services.
 
 import json
 import os
+import stat
 import tempfile
 
 # Path to local credentials file, used in local development.
@@ -14,22 +15,23 @@ CREDENTIALS_PATH = os.environ.get("CREDENTIALS_PATH")
 CREDENTIALS = os.environ.get("CREDENTIALS")
 
 
-def set_credentials():
-  if not CREDENTIALS and not CREDENTIALS_PATH:
+def set_credentials(credentials: str = None, credentials_path: str = None):
+  if not credentials and not credentials_path:
     raise ValueError(
-        "No credentials found. Ensure CREDENTIALS or CREDENTIALS_PATH is set.")
+        "No credentials found. Ensure credentials or credentials path is set.")
 
-  if CREDENTIALS_PATH:
-    if os.path.exists(CREDENTIALS_PATH):
-      os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = CREDENTIALS_PATH
+  if credentials_path:
+    if os.path.exists(credentials_path):
+      os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = credentials_path
       return
-    raise FileNotFoundError(f"Credentials file not found: {CREDENTIALS_PATH}")
+    raise FileNotFoundError(f"Credentials file not found: {credentials_path}")
 
   # Create a temporary file to store credentials for
   # services that don't accept string format credentials.
   with tempfile.NamedTemporaryFile(mode="w", suffix=".json",
                                    delete=False) as cred_file:
-    cred_file.write(CREDENTIALS)
+    cred_file.write(credentials)
+    os.chmod(cred_file.name, stat.S_IRUSR)
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred_file.name
 
 


### PR DESCRIPTION
This change sets the GOOGLE_APPLICATION_CREDENTIALS environment variable to a temporary file that contains the service account credentials.

It's necessary because Vertex AI cannot use the credentials JSON string.