### PR TITLE
[#71] Add custom prompt option

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ class VoteOptions(enum.Enum):
 
 
 def vote(vote_button, response_a, response_b, model_a_name, model_b_name,
-         user_prompt, instruction, category, source_lang, target_lang):
+         prompt, instruction, category, source_lang, target_lang):
   doc_id = uuid4().hex
   winner = VoteOptions(vote_button).name.lower()
 
@@ -37,7 +37,7 @@ def vote(vote_button, response_a, response_b, model_a_name, model_b_name,
 
   doc = {
       "id": doc_id,
-      "prompt": user_prompt,
+      "prompt": prompt,
       "instruction": instruction,
       "model_a": model_a_name,
       "model_b": model_b_name,
@@ -116,7 +116,7 @@ with gr.Blocks(title="Arena", css=css) as app:
   model_names = [gr.State(None), gr.State(None)]
   response_boxes = [gr.State(None), gr.State(None)]
 
-  prompt = gr.TextArea(label="Prompt", lines=4)
+  prompt_textarea = gr.TextArea(label="Prompt", lines=4)
   submit = gr.Button()
 
   with gr.Group():
@@ -166,7 +166,10 @@ with gr.Blocks(title="Arena", css=css) as app:
           category_radio, source_language, target_language, submit, vote_row,
           model_name_row
       ]).then(fn=get_responses,
-              inputs=[prompt, category_radio, source_language, target_language],
+              inputs=[
+                  prompt_textarea, category_radio, source_language,
+                  target_language
+              ],
               outputs=response_boxes + model_names + [instruction_state])
   submit_event.success(fn=lambda: gr.Row(visible=True), outputs=vote_row)
   submit_event.then(
@@ -179,7 +182,7 @@ with gr.Blocks(title="Arena", css=css) as app:
       outputs=[category_radio, source_language, target_language, submit])
 
   common_inputs = response_boxes + model_names + [
-      prompt, instruction_state, category_radio, source_language,
+      prompt_textarea, instruction_state, category_radio, source_language,
       target_language
   ]
   common_outputs = [option_a, option_b, tie, model_name_row]

--- a/model.py
+++ b/model.py
@@ -25,8 +25,8 @@ decoded_secret = models_secret.payload.data.decode("UTF-8")
 
 supported_models_json = json.loads(decoded_secret)
 
-DEFAULT_SUMMARIZE_PROMPT = "Summarize the following text, maintaining the language of the text."  # pylint: disable=line-too-long
-DEFAULT_TRANSLATE_PROMPT = "Translate the following text from {source_lang} to {target_lang}."  # pylint: disable=line-too-long
+DEFAULT_SUMMARIZE_INSTRUCTION = "Summarize the following text, maintaining the language of the text."  # pylint: disable=line-too-long
+DEFAULT_TRANSLATE_INSTRUCTION = "Translate the following text from {source_lang} to {target_lang}."  # pylint: disable=line-too-long
 
 
 class Model:
@@ -39,14 +39,14 @@ class Model:
       # Model attributes, we need to use the same camelCase names.
       apiKey: str = None,  # pylint: disable=invalid-name
       apiBase: str = None,  # pylint: disable=invalid-name
-      summarizePrompt: str = None,  # pylint: disable=invalid-name
-      translatePrompt: str = None):  # pylint: disable=invalid-name
+      summarizeInstruction: str = None,  # pylint: disable=invalid-name
+      translateInstruction: str = None):  # pylint: disable=invalid-name
     self.name = name
     self.provider = provider
     self.api_key = apiKey
     self.api_base = apiBase
-    self.summarize_prompt = summarizePrompt or DEFAULT_SUMMARIZE_PROMPT
-    self.translate_prompt = translatePrompt or DEFAULT_TRANSLATE_PROMPT
+    self.summarize_instruction = summarizeInstruction or DEFAULT_SUMMARIZE_INSTRUCTION  # pylint: disable=line-too-long
+    self.translate_instruction = translateInstruction or DEFAULT_TRANSLATE_INSTRUCTION  # pylint: disable=line-too-long
 
   def completion(self, messages: List, max_tokens: float = None) -> str:
     response = litellm.completion(model=self.provider + "/" +

--- a/response.py
+++ b/response.py
@@ -41,14 +41,14 @@ class Category(enum.Enum):
 def get_instruction(category: str, model: Model, source_lang: str,
                     target_lang: str):
   if category == Category.SUMMARIZE.value:
-    return model.summarize_prompt
+    return model.summarize_instruction
 
   if category == Category.TRANSLATE.value:
-    return model.translate_prompt.format(source_lang=source_lang,
-                                         target_lang=target_lang)
+    return model.translate_instruction.format(source_lang=source_lang,
+                                              target_lang=target_lang)
 
 
-def get_responses(user_prompt: str, category: str, source_lang: str,
+def get_responses(prompt: str, category: str, source_lang: str,
                   target_lang: str):
   if not category:
     raise gr.Error("Please select a category.")
@@ -68,9 +68,9 @@ def get_responses(user_prompt: str, category: str, source_lang: str,
           "content": instruction
       }, {
           "role": "user",
-          "content": user_prompt
+          "content": prompt
       }])
-      create_history(model.name, instruction, user_prompt, response)
+      create_history(model.name, instruction, prompt, response)
       responses.append(response)
 
     # TODO(#1): Narrow down the exception type.


### PR DESCRIPTION
Changes:
- It will look for a `summarizeInstruction` or a `translateInstruction` config for each model and use it as a prompt
- A default prompt is used if no instruction is found
- The prompt requests a JSON format response