### PR TITLE
[#75|#79] Reactivate Run button after an error is thrown

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,29 +130,55 @@ with gr.Blocks(title="Arena", css=css) as app:
     option_b = gr.Button(VoteOptions.MODEL_B.value)
     tie = gr.Button(VoteOptions.TIE.value)
 
-  vote_buttons = [option_a, option_b, tie]
   instruction_state = gr.State("")
+
+  # The following elements need to be reset when the user changes
+  # the category, source language, or target language.
+  ui_elements = [
+      response_boxes[0], response_boxes[1], model_names[0], model_names[1],
+      instruction_state, model_name_row, vote_row
+  ]
+
+  def reset_ui():
+    return [gr.Textbox(value="") for _ in range(4)
+           ] + [gr.State(""),
+                gr.Row(visible=False),
+                gr.Row(visible=False)]
+
+  category_radio.change(fn=reset_ui, outputs=ui_elements)
+  source_language.change(fn=reset_ui, outputs=ui_elements)
+  target_language.change(fn=reset_ui, outputs=ui_elements)
 
   submit_event = submit.click(
       fn=lambda: [
+          gr.Radio(interactive=False),
+          gr.Dropdown(interactive=False),
+          gr.Dropdown(interactive=False),
           gr.Button(interactive=False),
           gr.Row(visible=False),
           gr.Row(visible=False)
       ],
-      outputs=[submit, vote_row, model_name_row]).then(
-          fn=get_responses,
-          inputs=[prompt, category_radio, source_language, target_language],
-          outputs=response_boxes + model_names + [instruction_state])
-  submit_event.success(fn=lambda: [gr.Row(visible=True)] +
-                       [gr.Button(interactive=True) for _ in range(3)],
-                       outputs=[vote_row] + vote_buttons)
-  submit_event.then(fn=lambda: gr.Button(interactive=True), outputs=submit)
+      outputs=[
+          category_radio, source_language, target_language, submit, vote_row,
+          model_name_row
+      ]).then(fn=get_responses,
+              inputs=[prompt, category_radio, source_language, target_language],
+              outputs=response_boxes + model_names + [instruction_state])
+  submit_event.success(fn=lambda: gr.Row(visible=True), outputs=vote_row)
+  submit_event.then(
+      fn=lambda: [
+          gr.Radio(interactive=True),
+          gr.Dropdown(interactive=True),
+          gr.Dropdown(interactive=True),
+          gr.Button(interactive=True)
+      ],
+      outputs=[category_radio, source_language, target_language, submit])
 
   common_inputs = response_boxes + model_names + [
       prompt, instruction_state, category_radio, source_language,
       target_language
   ]
-  common_outputs = vote_buttons + [model_name_row]
+  common_outputs = [option_a, option_b, tie, model_name_row]
   option_a.click(vote, [option_a] + common_inputs, common_outputs)
   option_b.click(vote, [option_b] + common_inputs, common_outputs)
   tie.click(vote, [tie] + common_inputs, common_outputs)


### PR DESCRIPTION
Changes: 
- Reactivates the Run button after an error is thrown so that users can retry the run without having to refresh the page.
- Block category change while generating responses.
- Reset Responses, Vote when users change the category so that users couldn't vote with a different category.

Screenshot: https://screen.yanolja.in/fx4IuOJowzWBRIaF.png
![image](https://github.com/Y-IAB/arena/assets/124246127/bcb0bb49-2910-4b82-ba61-69c683df18cf)


Fixes #75
Fixes #79