### PR TITLE
[#21] Fix Firestore auto-reload issue

### DIFF
--- a/leaderboard.py
+++ b/leaderboard.py
@@ -16,9 +16,9 @@ import pandas as pd
 
 from credentials import get_credentials_json
 
-# TODO(#21): Fix auto-reload issue related to the initialization of Firebase.
-firebase_admin.initialize_app(credentials.Certificate(get_credentials_json()))
-db = firestore.client()
+if gr.NO_RELOAD:
+  firebase_admin.initialize_app(credentials.Certificate(get_credentials_json()))
+  db = firestore.client()
 
 SUPPORTED_TRANSLATION_LANGUAGES = [
     language.name.capitalize() for language in lingua.Language.all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,8 @@ google-cloud-storage==2.14.0
 google-crc32c==1.5.0
 google-resumable-media==2.7.0
 googleapis-common-protos==1.62.0
-gradio==4.22.0
-gradio_client==0.13.0
+gradio==4.23.0
+gradio_client==0.14.0
 grpc-google-iam-v1==0.13.0
 grpcio==1.60.1
 grpcio-status==1.60.1


### PR DESCRIPTION
Gradio 4.23.0 introduced a new feature that prevents execution during auto-reload. This change fixes the existing Firestore reloading issue by upgrading Gradio to 4.23.0.

Fixes #21