### PR TITLE
[#100] Add Grog API key for Llama 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Get Involved: [Discuss and contribute on GitHub](https://github.com/yanolja/aren
    ANTHROPIC_API_KEY=<your key> \
    MISTRAL_API_KEY=<your key> \
    GEMINI_API_KEY=<your key> \
+   GROQ_API_KEY=<your key> \
    python3 app.py
    ```
 


### PR DESCRIPTION
This change adds [Grog](https://groq.com/) key to the README which is necessary for supporting the Llama 3 model.

resolves #100