### PR TITLE
[#106] Display only one leaderboard table based on filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ import lingua
 
 from leaderboard import build_leaderboard
 from leaderboard import db
-from leaderboard import SUPPORTED_TRANSLATION_LANGUAGES
+from leaderboard import SUPPORTED_LANGUAGES
 from model import check_models
 from model import supported_models
 import response
@@ -87,14 +87,14 @@ with gr.Blocks(title="Arena", css=css) as app:
         info="The chosen category determines the instruction sent to the LLMs.")
 
     source_language = gr.Dropdown(
-        choices=SUPPORTED_TRANSLATION_LANGUAGES,
+        choices=SUPPORTED_LANGUAGES,
         value="English",
         label="Source language",
         info="Choose the source language for translation.",
         interactive=True,
         visible=False)
     target_language = gr.Dropdown(
-        choices=SUPPORTED_TRANSLATION_LANGUAGES,
+        choices=SUPPORTED_LANGUAGES,
         value="Spanish",
         label="Target language",
         info="Choose the target language for translation.",

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -122,8 +122,8 @@ def build_leaderboard():
   with gr.Tabs():
 
     # Returns (original leaderboard, filtered leaderboard).
-    def toggle_leaderboard(value: str) -> Tuple[gr.Dataframe, gr.Dataframe]:
-      filter_chosen = value != ANY_LANGUAGE
+    def toggle_leaderboard(language: str) -> Tuple[gr.Dataframe, gr.Dataframe]:
+      filter_chosen = language != ANY_LANGUAGE
       return gr.Dataframe(visible=not filter_chosen), gr.Dataframe(
           visible=filter_chosen)
 
@@ -154,8 +154,8 @@ def build_leaderboard():
           fn=update_filtered_leaderboard,
           inputs=[
               gr.State(LeaderboardTab.SUMMARIZATION), summary_language,
-              gr.State(),
-              gr.State()
+              gr.State(None),
+              gr.State(None)
           ],
           outputs=filtered_summarization).then(
               fn=toggle_leaderboard,
@@ -195,7 +195,7 @@ def build_leaderboard():
           fn=update_filtered_leaderboard,
           inputs=[
               gr.State(LeaderboardTab.TRANSLATION),
-              gr.State(), source_language, target_language
+              gr.State(None), source_language, target_language
           ],
           outputs=filtered_translation).then(
               fn=toggle_leaderboard,
@@ -205,7 +205,7 @@ def build_leaderboard():
           fn=update_filtered_leaderboard,
           inputs=[
               gr.State(LeaderboardTab.TRANSLATION),
-              gr.State(), source_language, target_language
+              gr.State(None), source_language, target_language
           ],
           outputs=filtered_translation).then(
               fn=toggle_leaderboard,

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -123,8 +123,9 @@ def build_leaderboard():
 
     # Returns (original leaderboard, filtered leaderboard).
     def toggle_leaderboard(value: str) -> Tuple[gr.Dataframe, gr.Dataframe]:
-      return gr.Dataframe(visible=value == ANY_LANGUAGE), gr.Dataframe(
-          visible=value != ANY_LANGUAGE)
+      filter_chosen = value != ANY_LANGUAGE
+      return gr.Dataframe(visible=not filter_chosen), gr.Dataframe(
+          visible=filter_chosen)
 
     with gr.Tab(LeaderboardTab.SUMMARIZATION.value):
       summary_language = gr.Dropdown(choices=SUPPORTED_LANGUAGES +

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -123,9 +123,8 @@ def build_leaderboard():
 
     # Returns (original leaderboard, filtered leaderboard).
     def toggle_leaderboard(value: str) -> Tuple[gr.Dataframe, gr.Dataframe]:
-      if value == ANY_LANGUAGE:
-        return gr.Dataframe(visible=True), gr.Dataframe(visible=False)
-      return gr.Dataframe(visible=False), gr.Dataframe(visible=True)
+      return gr.Dataframe(visible=value == ANY_LANGUAGE), gr.Dataframe(
+          visible=value != ANY_LANGUAGE)
 
     with gr.Tab(LeaderboardTab.SUMMARIZATION.value):
       summary_language = gr.Dropdown(choices=SUPPORTED_LANGUAGES +


### PR DESCRIPTION
This change updates the leaderboard display behavior to show only one table at a time.

- If the language filter is set to 'Any', the original, unfiltered leaderboard is displayed.
- If a specific language is selected, a filtered leaderboard is shown.

### Before Change
<img width="1516" alt="스크린샷 2024-06-05 오후 12 40 41" src="https://github.com/yanolja/arena/assets/124246127/9b1e77dd-e350-4ee9-a08a-4dd5303d5789">

### After Change
<img width="1534" alt="스크린샷 2024-06-05 오후 12 41 44" src="https://github.com/yanolja/arena/assets/124246127/0839b738-c5c7-4789-b6f4-527995d78839">

resolved #106 