### PR TITLE
[#78] Handle identical ELO ratings

### DIFF
--- a/leaderboard.py
+++ b/leaderboard.py
@@ -103,8 +103,19 @@ def load_elo_ratings(tab,
   ratings = compute_elo(battles)
 
   sorted_ratings = sorted(ratings.items(), key=lambda x: x[1], reverse=True)
-  return [[i + 1, model, math.floor(rating + 0.5)]
-          for i, (model, rating) in enumerate(sorted_ratings)]
+
+  rank = 0
+  last_rating = None
+  rating_rows = []
+  for index, (model, rating) in enumerate(sorted_ratings):
+    int_rating = math.floor(rating + 0.5)
+    if int_rating != last_rating:
+      rank = index + 1
+
+    rating_rows.append([rank, model, int_rating])
+    last_rating = int_rating
+
+  return rating_rows
 
 
 LEADERBOARD_UPDATE_INTERVAL = 600  # 10 minutes


### PR DESCRIPTION
This change modifies the load_elo_ratings function to assign the same rank to models with identical integer ELO ratings.
<img width="1543" alt="스크린샷 2024-06-03 오후 4 57 21" src="https://github.com/yanolja/arena/assets/124246127/0d7166d8-d545-43e8-a3f6-f2eabe936375">

resolves #78