### PR TITLE
[#128] Add Gemma 2 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Get Involved: [Discuss and contribute on GitHub](https://github.com/yanolja/aren
    MISTRAL_API_KEY=<your key> \
    GEMINI_API_KEY=<your key> \
    GROQ_API_KEY=<your key> \
+   DEEPINFRA_API_KEY=<your key> \
    python3 app.py
    ```
 

--- a/model.py
+++ b/model.py
@@ -43,7 +43,7 @@ class Model:
             "system",
         "content":
             instruction + """
-Output following this JSON format:
+Output following this JSON format without using code blocks:
 {"result": "your result here"}"""
     }, {
         "role": "user",
@@ -166,6 +166,8 @@ supported_models: List[Model] = [
     Model("mistral-large-2402", provider="mistral"),
     Model("llama3-8b-8192", provider="groq"),
     Model("llama3-70b-8192", provider="groq"),
+    Model("google/gemma-2-9b-it", provider="deepinfra"),
+    Model("google/gemma-2-27b-it", provider="deepinfra"),
     EeveModel("yanolja/EEVE-Korean-Instruct-10.8B-v1.0",
               provider="openai",
               api_base=os.getenv("EEVE_API_BASE"),
@@ -177,7 +179,9 @@ def check_models(models: List[Model]):
   for model in models:
     print(f"Checking model {model.name}...")
     try:
-      model.completion("You are an AI model.", "Hello, world!")
+      model.completion(
+          """Output following this JSON format without using code blocks:
+{"result": "your result here"}""", "How are you?")
       print(f"Model {model.name} is available.")
 
     # This check is designed to verify the availability of the models


### PR DESCRIPTION
- Issue: #128
There has been a request to add support for the Gemma 2 models.

This change adds the Gemma 2 models to the supported models using [deepinfra](https://deepinfra.com/) API.
The new models tend to answer using code blocks, so the instruction has been updated to prevent it.