### PR TITLE
[#130] Update non-JSON response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Get Involved: [Discuss and contribute on GitHub](https://github.com/yanolja/aren
    ANTHROPIC_API_KEY=<your key> \
    MISTRAL_API_KEY=<your key> \
    GEMINI_API_KEY=<your key> \
-   GROQ_API_KEY=<your key> \
    DEEPINFRA_API_KEY=<your key> \
    python3 app.py
    ```

--- a/response.py
+++ b/response.py
@@ -22,6 +22,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+
 # TODO(#37): Move DB operations to db.py.
 def get_history_collection(category: str):
   if category == Category.SUMMARIZE.value:
@@ -89,13 +90,17 @@ def get_responses(prompt: str, category: str, source_lang: str,
 
   models: List[Model] = sample(list(supported_models), 2)
   responses = []
+  got_invalid_response = False
   for model in models:
     instruction = get_instruction(category, model, source_lang, target_lang)
     try:
       # TODO(#1): Allow user to set configuration.
-      response = model.completion(instruction, prompt)
+      response, is_parsed = model.completion(instruction, prompt)
       create_history(category, model.name, instruction, prompt, response)
       responses.append(response)
+
+      if not is_parsed:
+        got_invalid_response = True
 
     except ContextWindowExceededError as e:
       logger.exception("Context window exceeded for model %s.", model.name)
@@ -105,6 +110,9 @@ def get_responses(prompt: str, category: str, source_lang: str,
     except Exception as e:
       logger.exception("Failed to get response from model %s.", model.name)
       raise gr.Error("Failed to get response. Please try again.") from e
+
+  if got_invalid_response:
+    gr.Warning("An invalid response was received.")
 
   model_names = [model.name for model in models]
 

--- a/response.py
+++ b/response.py
@@ -95,11 +95,11 @@ def get_responses(prompt: str, category: str, source_lang: str,
     instruction = get_instruction(category, model, source_lang, target_lang)
     try:
       # TODO(#1): Allow user to set configuration.
-      response, is_parsed = model.completion(instruction, prompt)
+      response, is_valid_response = model.completion(instruction, prompt)
       create_history(category, model.name, instruction, prompt, response)
       responses.append(response)
 
-      if not is_parsed:
+      if not is_valid_response:
         got_invalid_response = True
 
     except ContextWindowExceededError as e:


### PR DESCRIPTION

## Description
- Closes #130

Arena frequently throws errors due to receiving non-JSON responses, causing users to encounter errors too often. This significantly impacts the user experience by forcing manual retries.

## Changes
1. **Retry Mechanism**:  
   When Arena receives a non-JSON response, it will now automatically retry. In testing, some invalid responses were initially received, but after retrying, all responses were valid. While the test sample size was small, it was enough to show that the retry mechanism reduces the occurrence of invalid responses.

2. **Provider Switch**:  
   The Llama models provided by Groq were found to be unreliable, even with retries. The provider has been switched to DeepInfra, which consistently returned valid responses after retries.

3. **Handling Invalid Responses**:  
   If, after retries, an invalid response is still received, the system will return the response with a warning instead of throwing an error. While the format might be incorrect, the content is usually valid. This allows users to continue without needing to rerun the process.
<img width="2168" alt="스크린샷 2024-09-07 오후 3 46 09" src="https://github.com/user-attachments/assets/c9af8e48-b85d-49e0-b57c-b98d12d4b67b">

