### PR TITLE
[#128] Add Llama3.1 models and update GPT models

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Get Involved: [Discuss and contribute on GitHub](https://github.com/yanolja/aren
    TRANSLATIONS_COLLECTION=<your collection> \
    OPENAI_API_KEY=<your key> \
    ANTHROPIC_API_KEY=<your key> \
-   MISTRAL_API_KEY=<your key> \
    GEMINI_API_KEY=<your key> \
    DEEPINFRA_API_KEY=<your key> \
    python3 app.py

--- a/model.py
+++ b/model.py
@@ -153,7 +153,8 @@ class EeveModel(Model):
 
 
 supported_models: List[Model] = [
-    Model("gpt-4o-2024-05-13"),
+    Model("gpt-4o-2024-08-06"),
+    Model("gpt-4o-mini-2024-07-18"),
     Model("gpt-4-turbo-2024-04-09"),
     Model("gpt-4-0125-preview"),
     Model("gpt-3.5-turbo-0125"),
@@ -166,6 +167,9 @@ supported_models: List[Model] = [
     Model("mistral-large-2402", provider="mistral"),
     Model("llama3-8b-8192", provider="groq"),
     Model("llama3-70b-8192", provider="groq"),
+    Model("meta-llama/Meta-Llama-3.1-8B-Instruct", provider="deepinfra"),
+    Model("meta-llama/Meta-Llama-3.1-70B-Instruct", provider="deepinfra"),
+    Model("meta-llama/Meta-Llama-3.1-405B-Instruct", provider="deepinfra"),
     Model("google/gemma-2-9b-it", provider="deepinfra"),
     Model("google/gemma-2-27b-it", provider="deepinfra"),
     EeveModel("yanolja/EEVE-Korean-Instruct-10.8B-v1.0",

--- a/model.py
+++ b/model.py
@@ -142,47 +142,21 @@ class VertexModel(Model):
     }
 
 
-class EeveModel(Model):
-
-  def _get_completion_kwargs(self):
-    json_template = {
-        "type": "object",
-        "properties": {
-            "result": {
-                "type": "string"
-            }
-        }
-    }
-    return {
-        "extra_body": {
-            "guided_json": json.dumps(json_template),
-            "guided_decoding_backend": "lm-format-enforcer"
-        }
-    }
-
-
 supported_models: List[Model] = [
     Model("gpt-4o-2024-08-06"),
     Model("gpt-4o-mini-2024-07-18"),
-    Model("gpt-4-turbo-2024-04-09"),
-    Model("gpt-4-0125-preview"),
-    Model("gpt-3.5-turbo-0125"),
-    AnthropicModel("claude-3-opus-20240229"),
-    AnthropicModel("claude-3-sonnet-20240229"),
-    AnthropicModel("claude-3-haiku-20240307"),
+    AnthropicModel("claude-3-5-sonnet-20240620"),
     VertexModel("gemini-1.5-pro-001",
                 vertex_credentials=os.getenv("VERTEX_CREDENTIALS")),
-    Model("mistral-small-2402", provider="mistral"),
-    Model("mistral-large-2402", provider="mistral"),
+    VertexModel("gemini-1.5-flash-preview-0514",
+                vertex_credentials=os.getenv("VERTEX_CREDENTIALS")),
     Model("meta-llama/Meta-Llama-3.1-8B-Instruct", provider="deepinfra"),
     Model("meta-llama/Meta-Llama-3.1-70B-Instruct", provider="deepinfra"),
     Model("meta-llama/Meta-Llama-3.1-405B-Instruct", provider="deepinfra"),
+    Model("Qwen/Qwen2.5-72B-Instruct", provider="deepinfra"),
+    Model("Qwen/Qwen2-72B-Instruct", provider="deepinfra"),
     Model("google/gemma-2-9b-it", provider="deepinfra"),
     Model("google/gemma-2-27b-it", provider="deepinfra"),
-    EeveModel("yanolja/EEVE-Korean-Instruct-10.8B-v1.0",
-              provider="openai",
-              api_base=os.getenv("EEVE_API_BASE"),
-              api_key=os.getenv("EEVE_API_KEY")),
 ]
 
 


### PR DESCRIPTION
- Issue: #128


This change adds the Llama3.1 models to the supported models using [deepinfra](https://deepinfra.com/) and updates GPT models to newer versions.