### PR TITLE
[#141] Update GPT-4o to latest version

### DIFF
--- a/model.py
+++ b/model.py
@@ -143,7 +143,7 @@ class VertexModel(Model):
 
 
 supported_models: List[Model] = [
-    Model("gpt-4o-2024-08-06"),
+    Model("gpt-4o-2024-11-20"),
     Model("gpt-4o-mini-2024-07-18"),
     AnthropicModel("claude-3-5-sonnet-20241022"),
     AnthropicModel("claude-3-5-haiku-20241022"),


### PR DESCRIPTION
- close #141 

OpenAI has released an updated version of GPT-4o (gpt-4o-2024-11-20). We should update our Arena implementation from the current version (gpt-4o-2024-08-06).

